### PR TITLE
Small fix on tutor dashboard & request page

### DIFF
--- a/Dashboard/templates/Dashboard/tutor_dashboard.html
+++ b/Dashboard/templates/Dashboard/tutor_dashboard.html
@@ -10,6 +10,7 @@
         <h3 style="color: #600d91">Welcome to Your Tutor Dashboard</h3>
           <br>
             <p class="col-md-8 fs-4">Upcoming Sessions:</p>
+            {% if upcomingSessions %}
             {% for session, student_profile in upcomingSessions%} 
             <div class="modal-content rounded-4 shadow">
               <div class="modal-body p-5 pt-10">
@@ -68,10 +69,14 @@
            </div>
           <br>
           {%endfor%}
+          {%else%}
+          <p style="color:#AC658F; margin-left: 20px"> You currently have no upcoming sessions. <p>
+          {%endif%}
         </div>    
         
             <br>
             <p class="col-md-8 fs-4">Completed Sessions:</p>
+            {% if pastSessions %}
             {% for session, student_profile in pastSessions%}
             <div class="modal-content rounded-4 shadow">
               <div class="modal-body p-5 pt-10">
@@ -102,6 +107,9 @@
            </div>
           <br>
           {%endfor%}
+          {%else%}        
+          <p style="color:#AC658F; margin-left: 20px"> You currently have no completed sessions. <p>
+          {%endif%}
         </div>
     </div>
 </div>

--- a/Dashboard/templates/Dashboard/tutor_dashboard.html
+++ b/Dashboard/templates/Dashboard/tutor_dashboard.html
@@ -20,7 +20,7 @@
                   </div>
                   <div class="col-md-4">
                     <p><strong>Student Name:</strong> {{ student_profile.fname }} {{ student_profile.lname }}</p>
-                    <p><strong>Subject:</strong> {{ session.subject | title }}</p>
+                    <p><strong>Subject:</strong> {{ session.human_readable_subject | title }}</p>
                     <p><strong>Tutoring Mode: </strong>
                       {% if session.tutoring_mode == "inperson"  %} 
                       In Person

--- a/Dashboard/templates/Dashboard/tutor_request.html
+++ b/Dashboard/templates/Dashboard/tutor_request.html
@@ -19,7 +19,7 @@
                   </div>
                   <div class="col-md-4">
                     <p><strong>Student Name:</strong> {{ student_profile.fname }} {{ student_profile.lname }}</p>
-                    <p><strong>Subject:</strong> {{ tutorRequest.subject | title }}</p>
+                    <p><strong>Subject:</strong> {{ tutorRequest.human_readable_subject | title }}</p>
                     <p><strong>Tutoring Mode: </strong>
                       {% if tutorRequest.tutoring_mode == "inperson"  %} 
                       In Person

--- a/Dashboard/templates/Dashboard/tutor_request.html
+++ b/Dashboard/templates/Dashboard/tutor_request.html
@@ -9,6 +9,7 @@
     <div class="mt-4">
         <h3 style="color: #600d91">Your Tutoring Requests: </h3>
             <br>
+            {% if tutorRequests%}
             {% for tutorRequest, student_profile in tutorRequests%} 
             <div class="modal-content rounded-4 shadow">
               <div class="modal-body p-5 pt-10">
@@ -89,6 +90,9 @@
            </div>
           <br>
           {%endfor%}
+          {%else%}
+          <p style="color:#AC658F; margin-left: 20px"> You currently have no tutoring requests. <p>
+          {%endif%}
         </div>    
         </div>
     </div>

--- a/TutorRegister/models.py
+++ b/TutorRegister/models.py
@@ -72,9 +72,9 @@ class TutoringSession(models.Model):
     offering_rate = models.DecimalField(max_digits=6, decimal_places=0)
     message = models.TextField()
     status = models.TextField(default="Pending")
-    
+
     def human_readable_subject(self):
-        return self.subject.replace('_', ' ')
+        return self.subject.replace("_", " ")
 
 
 # Two blank lines before the new function definition

--- a/TutorRegister/models.py
+++ b/TutorRegister/models.py
@@ -72,6 +72,9 @@ class TutoringSession(models.Model):
     offering_rate = models.DecimalField(max_digits=6, decimal_places=0)
     message = models.TextField()
     status = models.TextField(default="Pending")
+    
+    def human_readable_subject(self):
+        return self.subject.replace('_', ' ')
 
 
 # Two blank lines before the new function definition


### PR DESCRIPTION
1. show messages when there is no session/request to show
<img width="660" alt="Screenshot 2024-03-22 at 11 18 47 PM" src="https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-2/assets/129098312/45e03475-4227-4b0a-818a-046ea1366f1f">

2. fix subject name: replace underscore with space