### PR TITLE
Empty likelist bug fix, Pagination&Tutor Filter UI adjustment

### DIFF
--- a/Dashboard/templates/Dashboard/dashboard.html
+++ b/Dashboard/templates/Dashboard/dashboard.html
@@ -121,17 +121,16 @@
 <!-- First part pagination -->
 <div class="pagination" style="display: flex; justify-content: center; align-items: center;">
     <span class="step-links" style="display: flex; gap: 10px; align-items: center;">
-        <span class="current" style="color: #600E90;">
-            Page {{ upcomingSessions.number }} of {{ upcomingSessions.paginator.num_pages }}.
-        </span>
         {% if upcomingSessions.has_previous %}
-            <a href="?upcoming_page=1&past_page={{ past_page }}">first</a>
-            <a href="?upcoming_page={{ upcomingSessions.previous_page_number }}&past_page={{ past_page }}">previous</a>
+            <a href="?upcoming_page=1&past_page={{ past_page }}">&laquo; First</a>
+            <a href="?upcoming_page={{ upcomingSessions.previous_page_number }}&past_page={{ past_page }}">Previous</a>
         {% endif %}
-        
+        <span class="current">
+            <b> Page {{ upcomingSessions.number }} of {{ upcomingSessions.paginator.num_pages }}.</b>
+        </span>
         {% if upcomingSessions.has_next %}
-            <a href="?upcoming_page={{ upcomingSessions.next_page_number }}&past_page={{ past_page }}">next</a>
-            <a href="?upcoming_page={{ upcomingSessions.paginator.num_pages }}&past_page={{ past_page }}">last</a>
+            <a href="?upcoming_page={{ upcomingSessions.next_page_number }}&past_page={{ past_page }}">Next</a>
+            <a href="?upcoming_page={{ upcomingSessions.paginator.num_pages }}&past_page={{ past_page }}">Last &raquo;</a>
         {% endif %}
     </span>
 </div>
@@ -208,17 +207,16 @@
 <!-- Second part pagination -->
 <div class="pagination" style="display: flex; justify-content: center; align-items: center;">
     <span class="step-links" style="display: flex; gap: 10px; align-items: center;">
-        <span class="current" style="color: #600E90;">
-            Page {{ pastSessions.number }} of {{ pastSessions.paginator.num_pages }}.
-        </span>
         {% if pastSessions.has_previous %}
-            <a href="?past_page=1&upcoming_page={{ upcoming_page }}"">first</a>
-            <a href="?past_page={{ pastSessions.previous_page_number }}&upcoming_page={{ upcoming_page }}">previous</a>
+            <a href="?past_page=1&upcoming_page={{ upcoming_page }}"">&laquo; First</a>
+            <a href="?past_page={{ pastSessions.previous_page_number }}&upcoming_page={{ upcoming_page }}">Previous</a>
         {% endif %}
-        
+        <span class="current">
+            <b> Page {{ pastSessions.number }} of {{ pastSessions.paginator.num_pages }}.</b>
+        </span>
         {% if pastSessions.has_next %}
-            <a href="?past_page={{ pastSessions.next_page_number }}&upcoming_page={{ upcoming_page }}">next</a>
-            <a href="?past_page={{ pastSessions.paginator.num_pages }}&upcoming_page={{ upcoming_page }}">last</a>
+            <a href="?past_page={{ pastSessions.next_page_number }}&upcoming_page={{ upcoming_page }}">Next</a>
+            <a href="?past_page={{ pastSessions.paginator.num_pages }}&upcoming_page={{ upcoming_page }}">Last &raquo;</a>
         {% endif %}
     </span>
 </div>

--- a/Dashboard/templates/Dashboard/requests.html
+++ b/Dashboard/templates/Dashboard/requests.html
@@ -149,17 +149,18 @@
             {% endfor %}
             <div class="pagination" style="display: flex; justify-content: center; align-items: center;">
                 <span class="step-links" style = "gap: 20px;">
-                    <span class="current" style="color: #600E90;">
-                        Page {{ tutorRequests.number }} of {{ tutorRequests.paginator.num_pages }}.
-                    </span>
                     {% if tutorRequests.has_previous %}
-                        <a href="?page=1">first</a>
-                        <a href="?page={{ tutorRequests.previous_page_number }}">previous</a>
+                        <a href="?page=1">&laquo; First</a>
+                        <a href="?page={{ tutorRequests.previous_page_number }}">Previous</a>
                     {% endif %}
-            
+                    
+                    <span class="current">
+                        <b> Page {{ tutorRequests.number }} of {{ tutorRequests.paginator.num_pages }}.</b>
+                    </span>
+
                     {% if tutorRequests.has_next %}
-                        <a href="?page={{ tutorRequests.next_page_number }}">next</a>
-                        <a href="?page={{ tutorRequests.paginator.num_pages }}">last</a>
+                        <a href="?page={{ tutorRequests.next_page_number }}">Next</a>
+                        <a href="?page={{ tutorRequests.paginator.num_pages }}">Last &raquo;</a>
                     {% endif %}
                     
                 </span>

--- a/Dashboard/templates/Dashboard/tutor_feedback.html
+++ b/Dashboard/templates/Dashboard/tutor_feedback.html
@@ -34,17 +34,18 @@
             {% endfor%}
             <div class="pagination" style="display: flex; justify-content: center; align-items: center;">
                 <span class="step-links" style="display: flex; gap: 10px; align-items: center;">
-                    <span class="current" style="color: #600E90;">
-                        Page {{ reviews.number }} of {{ reviews.paginator.num_pages }}.
-                    </span>
                     {% if reviews.has_previous %}
-                        <a href="?page=1">first</a>
-                        <a href="?page={{ reviews.previous_page_number }}">previous</a>
+                        <a href="?page=1">&laquo; First</a>
+                        <a href="?page={{ reviews.previous_page_number }}">Previous</a>
                     {% endif %}
                     
+                    <span class="current">
+                        <b> Page {{ reviews.number }} of {{ reviews.paginator.num_pages }}.</b>
+                    </span>
+
                     {% if reviews.has_next %}
-                        <a href="?page={{ reviews.next_page_number }}">next</a>
-                        <a href="?page={{ reviews.paginator.num_pages }}">last</a>
+                        <a href="?page={{ reviews.next_page_number }}">Next</a>
+                        <a href="?page={{ reviews.paginator.num_pages }}">Last &raquo;</a>
                     {% endif %}
                 </span>
             </div>

--- a/TutorFilter/forms.py
+++ b/TutorFilter/forms.py
@@ -89,7 +89,7 @@ class TutorFilterForm(forms.Form):
             choices=self.get_user_category_choices(user),
             required=False,
             widget=forms.Select(
-                attrs={"class": "form-select", "style": "margin-bottom: 10px;"}
+                attrs={"class": "form-select border-2", "style": "margin-bottom: 10px;"}
             ),
             label="Select a category..",
         )
@@ -97,14 +97,14 @@ class TutorFilterForm(forms.Form):
     preferred_mode = forms.ChoiceField(
         choices=MODE_CHOICES,
         widget=forms.Select(
-            attrs={"class": "form-select", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-select border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )
     grade = forms.ChoiceField(
         choices=GRADE_CHOICE,
         widget=forms.Select(
-            attrs={"class": "form-select", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-select border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )
@@ -112,7 +112,7 @@ class TutorFilterForm(forms.Form):
     expertise = forms.ChoiceField(
         choices=EXPERTISE_CHOICES,
         widget=forms.Select(
-            attrs={"class": "form-select", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-select border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )
@@ -120,34 +120,34 @@ class TutorFilterForm(forms.Form):
     zipcode = forms.CharField(
         max_length=255,
         widget=forms.TextInput(
-            attrs={"class": "form-control", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-control border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )
     salary_max = forms.IntegerField(
         widget=forms.NumberInput(
-            attrs={"class": "form-control", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-control border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )
     rating = forms.ChoiceField(
         choices=RATE_CHOICE,
         widget=forms.Select(
-            attrs={"class": "form-select", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-select border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )
     saved = forms.ChoiceField(
         choices=SORT_CHOICE,
         widget=forms.Select(
-            attrs={"class": "form-select", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-select border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )
     sortBy = forms.ChoiceField(
         choices=SORT_CHOICE,
         widget=forms.Select(
-            attrs={"class": "form-select", "style": "margin-bottom: 10px;"}
+            attrs={"class": "form-select border-2", "style": "margin-bottom: 10px;"}
         ),
         required=False,
     )

--- a/TutorFilter/templates/TutorFilter/filter_results.html
+++ b/TutorFilter/templates/TutorFilter/filter_results.html
@@ -117,24 +117,37 @@
         <!-- Repeat this block for each tutor result -->
         {% for user in users %}
         <div class="col">
-            <div class="card h-80">
+            <div class="card h-80  shadow">
                 <img src="{{ user.image.url }}" alt="Tutor" class="card-img-top" style="padding-top:10px; padding-left:50px; padding-right:50px">
                 <div style="padding-top:10px">
                     <div style="text-align:center; margin-bottom:10px">
                         <h5>{{ user.fname }} {{user.lname}}</h5>
                     </div>
                     <div style="padding-left:40px">
-                    <p class="lh-sm">Major: {{user.major}}</p>
-                    <p class="lh-sm">Grade: {{user.grade}}</p>
-                    <p class="lh-sm">Preferred Mode: {{user.preferred_mode}}</p>
-                    <p class="lh-sm">Zipcode: {{ user.zip }}</p>
-
+                    <p class="lh-sm"><b>Major:</b> {{user.major}}</p>
+                    <p class="lh-sm"><b>Grade:</b> {{user.grade|capfirst}}</p>
+                    <p class="lh-sm"><b>Preferred Mode:</b> {{user.preferred_mode|capfirst}}</p>
+                    <p class="lh-sm"><b>Zipcode:</b> {{ user.zip }}</p>
+                    <p class="lh-sm"><b>Salary:</b> ${{ user.salary_min }}-{{ user.salary_max }} /Hour</p>
                     {% for tutor_id, avg in average_ratings %}
                         {% if tutor_id == user.user_id %}
-                        <p class="lh-sm">Rating: {{ avg }}</p>
-                        {% endif %}
-                    {% endfor %}
-                    
+                            <div class="lh-sm">
+                              <span><b>Rating:</b></span>
+                                <span class="rating">
+                                  {% for _ in "12345" %}
+                                    {% if forloop.counter <= avg %}
+                                      <i class="fas fa-star" style="color: #600E90;"></i>
+                                  {% else %}
+                                    <i class="fas fa-star" style="color: #ccc;"></i>
+                                    {% endif %}
+                                {% endfor %}
+                          ({{ avg }})
+                          </span>
+                          
+        </div>
+    {% endif %}
+{% endfor %}
+<br>
                     </div>
                 <!-- More info as necessary -->
                 </div>
@@ -156,6 +169,7 @@
                         </div>
                     </div>
                 </div>
+                <br>
             <!-- Add interactive elements like buttons if needed -->
             </div>
         </div>
@@ -164,20 +178,21 @@
         {% endfor %}
     </div>
 </div>
-
-<div class="pagination" style="font-size: larger; display: flex; justify-content: center; align-items: center;">
+<br>
+<div class="pagination" style="display: flex; justify-content: center; align-items: center;">
     <span class="step-links" style = "gap: 20px;">
-        <span class="current" style="color: #600E90;">
-            Page {{ users.number }} of {{ users.paginator.num_pages }}.
-        </span>
         {% if users.has_previous %}
-            <a href="?page=1&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">first</a>
-            <a href="?page={{ users.previous_page_number }}&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">previous</a>
+            <a href="?page=1&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">&laquo; First</a>
+            <a href="?page={{ users.previous_page_number }}&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">Previous</a>
         {% endif %}
 
+        <span class="current">
+          <b> Page {{ users.number }} of {{ users.paginator.num_pages }}. </b>
+      </span>
+
         {% if users.has_next %}
-            <a href="?page={{ users.next_page_number }}&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">next</a>
-            <a href="?page={{ users.paginator.num_pages }}&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">last</a>
+            <a href="?page={{ users.next_page_number }}&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">Next</a>
+            <a href="?page={{ users.paginator.num_pages }}&preferred_mode={{ preferred_mode }}&grade={{ grade }}&expertise={{ expertise }}&rating={{ rating }}&zipcode={{ zipcode }}&salary_max={{ salary_max }}&category={{ category }}&sortBy={{ sort_By }}">Last &raquo;</a>
         {% endif %}
         
     </span>

--- a/TutorFilter/templates/TutorFilter/filter_results.html
+++ b/TutorFilter/templates/TutorFilter/filter_results.html
@@ -74,36 +74,36 @@
             <div class="row g-3 d-flex align-items-end"> <!-- Use align-items-end to align elements at the bottom -->
                 <!-- Add grid classes to each form group to control the width -->
                 <div class="form-group col-md-2">
-                    <label style="color: #600E90; "> {{ form.preferred_mode.label}}: </label>
+                    <label style="color: #600E90; "> <b>{{ form.preferred_mode.label}}:</b> </label>
                     {{ form.preferred_mode}}
                 </div>
                 <div class="form-group col-md-2">
-                    <label style="color: #600E90"> Tutor Grade:  </label>
+                    <label style="color: #600E90; "> <b>Tutor Grade:</b>  </label>
                     {{ form.grade}}
                 </div>
                 <div class="form-group col-md-2">
-                    <label style="color: #600E90"> Subject:  </label>
+                    <label style="color: #600E90; "> <b>Subject:</b>  </label>
                     {{ form.expertise}}
                 </div>
                 <div class="form-group col-md-2">
-                    <label style="color: #600E90"> Rating: </label>
+                    <label style="color: #600E90; "> <b>Rating:</b> </label>
                     {{ form.rating}}
                 </div>
                 <div class="form-group col-md-2">
-                    <label style="color: #600E90"> Zip Code:  </label>
+                    <label style="color: #600E90; "> <b>Zip Code:</b>  </label>
                     {{ form.zipcode}}
                 </div>
                 <div class="form-group col-md-2">
-                    <label style="color: #600E90"> Max Hourly Rate: </label>
+                    <label style="color: #600E90; "> <b>Max Hourly Rate:</b> </label>
                     {{ form.salary_max}}
                 </div>
                 <!-- For the second row, adjust the grid to allocate space for the button -->
                 <div class="form-group col-md-4">
-                    <label style="color: #600E90;"> My Saved Tutors: </label>
+                    <label style="color: #600E90;"> <b>My Saved Tutors:</b> </label>
                     {{ form.category}}
                 </div>
                 <div class="form-group col-md-4">
-                    <label style="color: #600E90"> Sort by: </label>
+                    <label style="color: #600E90; "> <b>Sort by:</b> </label>
                     {{ form.sortBy}}
                 </div>
                 <div class="col-md-4 d-flex col align-self-center justify-content-end"> <!-- Adjust this to move the button to the end -->
@@ -136,7 +136,7 @@
                                 <span class="rating">
                                   {% for _ in "12345" %}
                                     {% if forloop.counter <= avg %}
-                                      <i class="fas fa-star" style="color: #600E90;"></i>
+                                      <i class="fas fa-star" style="color: gold;"></i>
                                   {% else %}
                                     <i class="fas fa-star" style="color: #ccc;"></i>
                                     {% endif %}

--- a/TutorFilter/templates/TutorFilter/filter_results.html
+++ b/TutorFilter/templates/TutorFilter/filter_results.html
@@ -74,7 +74,7 @@
             <div class="row g-3 d-flex align-items-end"> <!-- Use align-items-end to align elements at the bottom -->
                 <!-- Add grid classes to each form group to control the width -->
                 <div class="form-group col-md-2">
-                    <label style="color: #600E90"> {{ form.preferred_mode.label}}: </label>
+                    <label style="color: #600E90; "> {{ form.preferred_mode.label}}: </label>
                     {{ form.preferred_mode}}
                 </div>
                 <div class="form-group col-md-2">
@@ -178,6 +178,7 @@
         {% endfor %}
     </div>
 </div>
+
 <br>
 <div class="pagination" style="display: flex; justify-content: center; align-items: center;">
     <span class="step-links" style = "gap: 20px;">
@@ -249,6 +250,7 @@
             <div class="form-group">
                 <p>New List Name:</p>
                 <input type="text" class="form-control" id="newListName" placeholder="List Name">
+                <div id="newListError" class="text-danger" style="display: none; color: red">Please enter a list name.</div>
             </div>
           </form>
         </div>
@@ -346,35 +348,42 @@ $(document).ready(function(){
 
   // When the user clicks on "Confirm" in the new list modal
   $('#confirmNewList').click(function() {
-    // Get the value from the input
-    var categoryName = $('#newListName').val();
+    var categoryName = $('#newListName').val().trim(); // Get the trimmed value from the input
+
+    // Check if the input is empty
+    if (!categoryName) {
+        $('#newListError').show(); // Show the error message
+        return; // Stop further execution
+    } else {
+        $('#newListError').hide(); // Ensure the error message is hidden if input is filled
+    }
 
     $.ajax({
-            url: "{% url 'TutorFilter:add_favorite' %}", // The URL to your Django view
-            type: "POST",
-            data: {
-                'category_name': categoryName,
-                'tutor_id': tutorId,
-                'csrfmiddlewaretoken': '{{ csrf_token }}' // CSRF token for security
-            },
-            success: function(data) {
-                if (data.status === 'success') {
-                // Refresh the page
-                 window.location.reload();
-                } else {
+        url: "{% url 'TutorFilter:add_favorite' %}", // The URL to your Django view
+        type: "POST",
+        data: {
+            'category_name': categoryName,
+            'tutor_id': tutorId,
+            'csrfmiddlewaretoken': '{{ csrf_token }}' // CSRF token for security
+        },
+        success: function(data) {
+            if (data.status === 'success') {
+                // Notify user of success, e.g., using an alert or updating the DOM
+                window.location.reload();
+            } else {
                 // Handle case where save was not successful
                 alert(data.message); // Simple alert for error
-                }
-            },
-            error: function(xhr, errmsg, err) {
-                // Handle error
-                console.log("Error adding category: " + errmsg);
             }
-        });
-    // Here you'd typically make an AJAX call to your Django view to process the new list creation
-    // After the AJAX call's success callback, you can hide the modal
-    newListModal.hide();
-  });
+        },
+        error: function(xhr, errmsg, err) {
+            // Handle error
+            console.log("Error adding category: " + errmsg);
+        }
+    });
+    // Hide the modal after successful AJAX call
+    $('#newListModal').modal('hide');
+});
+
 
   $('#confirmUnlike').click(function() {
     // Get the value from the input

--- a/TutorFilter/templates/TutorFilter/view_tutor_profile.html
+++ b/TutorFilter/templates/TutorFilter/view_tutor_profile.html
@@ -104,18 +104,17 @@
                             <br>
                             {% endfor %}
                             <div class="pagination" style="display: flex; justify-content: center; align-items: center;">
-                                <span class="step-links" style = "gap: 20px; color: #600E90;">
-                                    <span class="current">
-                                        Page {{ reviews.number }} of {{ reviews.paginator.num_pages }}.
-                                    </span>
+                                <span class="step-links" style = "gap: 20px;">
                                     {% if reviews.has_previous %}
-                                        <a href="?page=1">first</a>
-                                        <a href="?page={{ reviews.previous_page_number }}">previous</a>
+                                        <a href="?page=1">&laquo; First</a>
+                                        <a href="?page={{ reviews.previous_page_number }}">Previous</a>
                                     {% endif %}
-                            
+                                    <span class="current">
+                                        <b> Page {{ reviews.number }} of {{ reviews.paginator.num_pages }}.</b>
+                                    </span>
                                     {% if reviews.has_next %}
-                                        <a href="?page={{ reviews.next_page_number }}">next</a>
-                                        <a href="?page={{ reviews.paginator.num_pages }}">last</a>
+                                        <a href="?page={{ reviews.next_page_number }}">Next</a>
+                                        <a href="?page={{ reviews.paginator.num_pages }}">Last &raquo;</a>
                                     {% endif %}
                                 </span>
                             </div>


### PR DESCRIPTION
### 1. Prevent the user from adding a new like list with empty name:
![image](https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-2/assets/144174031/4af7adc2-a3fc-47e0-a340-33b2e8f686a6)
### 2. Adjust Tutor Filter UI to be consistent with other pages:
![image](https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-2/assets/144174031/5b0be858-2873-48c8-b143-4673fcdc0183)
### 3. Adjust pagination style:
![image](https://github.com/gcivil-nyu-org/INT2-Monday-Spring2024-Team-2/assets/144174031/935046ae-ecde-4fd6-b840-a6acc53333aa)
